### PR TITLE
Fix it's vs its typo.

### DIFF
--- a/stooge/frontend/static/partials/scan-results.html
+++ b/stooge/frontend/static/partials/scan-results.html
@@ -104,7 +104,7 @@
         </tr>
         <tr>
           <td class="shrink"><span class="label explanation-label label-info">ServerId</span></td>
-          <td class="expand">Does the server hide it's software version?</td>
+          <td class="expand">Does the server hide its software version?</td>
         </tr>
 
         <tr>


### PR DESCRIPTION
If the word can be expanded to 'it is' then use an appostrophe.
